### PR TITLE
Delay Timer to Accommodate Lane-Change Animation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -78,6 +78,8 @@ class Bot:
                             self.release()
                             self.right = False
                             self.center = True
+                            from time import sleep
+                            sleep(0.07)
                     # Right block
                     elif 175 > bx > 20:
                         if self.center:
@@ -88,6 +90,8 @@ class Bot:
                             self.release()
                             self.left = False
                             self.center = True
+                            from time import sleep
+                            sleep(0.07)
                     # Far left block
                     elif bx < -175 and self.right:
                         self.release()
@@ -132,6 +136,8 @@ class Bot:
                                 self.hold_right()
                                 self.right = True
                             self.center = False
+                            from time import sleep
+                            sleep(0.07)
                     # Left spike
                     elif sx < -20:
                         if self.left:


### PR DESCRIPTION
First off, this bot is a great way to actually get that 1 billion point achievement without getting CTS at the same time, so thanks a ton.

As you had said earlier, this bot wasn't supposed to be this fully fleshed out piece of software. However, I did find a small issue, the bot conducts lane changes and updates its status internally too quickly, while the lane-change animation (~120ms) still takes place. As a result, the actual lane and internally tracked lane can come out of sync temporarily. This can cause the following issue:

1. Bot is in the left lane
2. Bot sees a block in the middle lane
3. Bot commands a middle lane move and updates internal lane status
4. Animation starts
5. Bot sees the _same_ block still in the middle lane, but thinks it's looking at the left right lane (because the lane change animation is still ongoing)
6. Bot commands a right lane move and updates its internal lane.
7. Bot stabilizes in the right lane

This causes the bot to whiplash back and forth when it's on the side lane and sees a block in the middle lane.

Similarly, the same thing can happen with spikes in the middle lane when the bot is in the middle lane: it tries to move, then thinks it's in the new lane and sees the spike still in front of it, causing it to come back to the middle, and this repeats until it hits the spike.

This Pull Request simply adds a 70ms delay timer after the lane change command for those specific moves. It's not a perfect solution and still has issues in of itself, but is simply a bandaid. The bot definitely needs an overhaul in logic, but this isn't within the scope of this Pull Request.

I tried 60ms, 50ms, and 40ms as well. 70ms seems to be the boundary at which this whiplashing behavior mostly stops.

### RESULTS
Before the 70ms timer, the bot would consistently get 550-650k on a certain speedcore song. After adding the timer, this has gone up to 750-850k, almost matching manual playing (850-900k)